### PR TITLE
call `acquire` if `acquireStatus` fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-dotnet-pack",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "preview": true,
   "publisher": "ms-dotnettools",
   "author": "Microsoft Corporation",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,7 +59,14 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
 async function initializeDependencies() {
   // Acquire status for .NET SDK
   // TODO: Once we have an automated pipeline to have the latest SDK bundled with the education pack installer, we can change the below command to "dotnet-sdk.acquire", to get the latest SDK update.
-  const sdkResult = await initializeDependency("ms-dotnettools.vscode-dotnet-sdk", "dotnet-sdk.acquireStatus", { version: dotnetSdkVersion, requestingExtensionId: 'ms-dotnettools.vscode-dotnet-pack' });
+  let sdkResult = await initializeDependency("ms-dotnettools.vscode-dotnet-sdk", "dotnet-sdk.acquireStatus", { version: dotnetSdkVersion, requestingExtensionId: 'ms-dotnettools.vscode-dotnet-pack' });
+  if (!sdkResult?.dotnetPath) {
+    const acquirePromise = initializeDependency("ms-dotnettools.vscode-dotnet-sdk", "dotnet-sdk.acquire", { version: dotnetSdkVersion, requestingExtensionId: 'ms-dotnettools.vscode-dotnet-pack' });
+    sdkResult = await vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Notification, title: 'Acquiring latest .NET SDK...' },
+      (_progress, _token) => acquirePromise
+    );
+  }
 
   // Acquire .NET Interactive
   initializeDependency("ms-dotnettools.dotnet-interactive-vscode", "dotnet-interactive.acquire", sdkResult?.dotnetPath);


### PR DESCRIPTION
This wraps the long-running call to `acquire` and will display this UI:

![image](https://user-images.githubusercontent.com/926281/151074944-51c98c42-13a4-4bbd-8b9d-29e881941493.png)

Also includes a version number update.