### PR TITLE
don't execute `dotnet.gettingStarted` on activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-dotnet-pack",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "preview": true,
   "publisher": "ms-dotnettools",
   "author": "Microsoft Corporation",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,11 +7,8 @@ import { dispose as disposeTelemetryWrapper, initialize, instrumentOperation } f
 
 import { initialize as initUtils } from "./utils";
 import { initialize as initCommands } from "./commands";
-import { HelpViewType } from "./misc";
 import { initialize as initExp } from "./exp";
-import { scheduleAction } from "./utils/scheduler";
 
-const isDotnetGettingStartedPresented = 'isDotnetGettingStartedPresented';
 const dotnetSdkVersion = '6.0';
 
 interface DotnetPackExtensionExports {
@@ -45,34 +42,6 @@ async function initializeExtension(_operationId: string, context: vscode.Extensi
   initUtils(context);
   initCommands(context);
   initExp(context);
-
-  const config = vscode.workspace.getConfiguration("dotnet.help");
-
-  if (config.get("firstView") !== HelpViewType.None) {
-    scheduleAction("showFirstView", true).then(() => {
-      presentFirstView(context);
-    });
-  }
-}
-
-async function presentFirstView(context: vscode.ExtensionContext) {
-  const config = vscode.workspace.getConfiguration("dotnet.help");
-  const firstView = config.get("firstView");
-  switch (firstView) {
-    case HelpViewType.None:
-      break;
-    default:
-      await showGettingStartedView(context);
-  }
-}
-
-async function showGettingStartedView(context: vscode.ExtensionContext, _isForce: boolean = false) {
-  if (!!context.globalState.get(isDotnetGettingStartedPresented)) {
-    return;
-  }
-
-  await vscode.commands.executeCommand("dotnet.gettingStarted");
-  context.globalState.update(isDotnetGettingStartedPresented, true);
 }
 
 function initializeTelemetry(_context: vscode.ExtensionContext) {


### PR DESCRIPTION
When the education pack installer finishes, it launches VS Code and opens a notebook.  This activates the .NET Interactive extension which in turn activates this extension.  The activation of this extension used to open the sample notebook, then control would return to .NET Interactive which would then also open the sample notebook as requested, with the end result being that the user is presented with 2 copies of the same notebook.

The getting started command is still present and can still be invoked, it's just no longer done by default.